### PR TITLE
Changes the permit2 address for hemi

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "@uniswap/permit2-sdk",
-  "version": "1.2.0",
+  "name": "@hemilabs/permit2-sdk",
+  "version": "1.2.0-beta.1",
   "description": "An sdk for interacting with permit2.",
   "publishConfig": {
     "access": "public"

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,6 +1,6 @@
 import { BigNumber } from '@ethersproject/bignumber'
 
-export const PERMIT2_ADDRESS = '0x000000000022D473030F116dDEE9F6B43aC78BA3'
+export const PERMIT2_ADDRESS = '0xB952578f3520EE8Ea45b7914994dcf4702cEe578'
 
 export const MaxUint48 = BigNumber.from('0xffffffffffff')
 export const MaxUint160 = BigNumber.from('0xffffffffffffffffffffffffffffffffffffffff')


### PR DESCRIPTION
What the title says.
This is the contract: https://testnet.explorer.hemi.xyz/address/0xB952578f3520EE8Ea45b7914994dcf4702cEe578?tab=contract